### PR TITLE
make regex correctly capture heading tags

### DIFF
--- a/app/src/rtf/rtf.class.js
+++ b/app/src/rtf/rtf.class.js
@@ -7,7 +7,7 @@ const juice 		      = require('juice');
 const fs 				      = require('fs');
 
 class Rtf {
-  constructor() { 
+  constructor() {
     this.rtfHeaderOpening = "{\\rtf1\\ansi\\deff0{\\fonttbl {\\f0\\fnil\\fcharset0 Calibri;}{\\f1\\fnil\\fcharset2 Symbol;}}";
     this.rtfHeaderContent = '';
     this.rtfClosing = "}";
@@ -27,7 +27,7 @@ class Rtf {
   }
 
   swapHtmlStrangerTags(html, dafaultTag) {
-    return html.replace(/<(\/?[a-z-]+)( *[^>]*)?>/gi, (match, tagName, options) => {
+    return html.replace(/<(\/?[a-zA-Z_]+[a-zA-Z0-9_]*)( *[^>]*)?>/gi, (match, tagName, options) => {
       let newTag = !tagName.includes('/') ? `<${ dafaultTag }${ options ? options : '' }>` : `</${ dafaultTag }>`;
       return AllowedHtmlTags.isKnowedTag(tagName) ? match : `${ newTag }`;
     });
@@ -78,7 +78,7 @@ class Rtf {
       if(tableChildren[tbodyIndex].children[i].type != 'text') {
         (tableChildren[tbodyIndex].children[i].children).forEach((child, index) => {
           if(child.type != 'text')
-            count++;          
+            count++;
         });
         break;
       }
@@ -108,7 +108,7 @@ class Rtf {
 
   addContentOfTagInRtfCode(contentOfTag) {
     contentOfTag = MyString.removeCharacterOfEscapeInAllString(contentOfTag, '\n\t');
-   
+
     if(contentOfTag != undefined && !MyString.hasOnlyWhiteSpace(contentOfTag))
       this.rtfContentReferences.push({ content: this.addSpaceAroundString(contentOfTag.trim()), tag: false });
   }
@@ -132,7 +132,7 @@ class Rtf {
 
   clearCacheContent() {
     this.rtfHeaderContent = '';
-    this.rtfContentReferences = [];    
+    this.rtfContentReferences = [];
   }
 
 }


### PR DESCRIPTION
The numeric values in heading tags were being captured as part of the second regex group, which resulted in:
- rich text formatting appearing after h1-h6 tags
- font sizes not being reflected

Suggested changes make space for additional string patterns.  Strings must start with an alpha char, but can now be preceded by either alpha pr numeric characters. 